### PR TITLE
Disable `websocket` pings

### DIFF
--- a/cpgqls_client/client.py
+++ b/cpgqls_client/client.py
@@ -9,7 +9,7 @@ class CPGQLSTransport:
         self._ws_conn = None
 
     def connect(self, endpoint):
-        self._ws_conn = websockets.connect(endpoint)
+        self._ws_conn = websockets.connect(endpoint, ping_interval=None)
         return self._ws_conn
 
     async def recv(self):


### PR DESCRIPTION
Because of the current way the CPGQLServer is implemented, queries which
take longer than 30s time out. This behaviour does not seem necessary at
the moment, so we'll just disable it.
